### PR TITLE
macOS and related paths fixes

### DIFF
--- a/bundle_tools/drives.py
+++ b/bundle_tools/drives.py
@@ -48,17 +48,13 @@ def list_connected_drives(circuitpython_only: bool = True, drive_mount_point: Pa
         logger.debug("Platform is Mac OSX!")
         drive_mount_point = Path("/Volumes")
         for path in drive_mount_point.glob("*"):
-            if circuitpython_only and (path / "boot_out.txt").exists():
-                connected_drives.append(path)
-            else:
+            if not circuitpython_only or (path / "boot_out.txt").exists():
                 connected_drives.append(path)
     elif os_detect.on_linux():
         logger.debug("Platform is Linux!")
         for path in drive_mount_point.glob("*"):
             try:
-                if circuitpython_only and (path / "boot_out.txt").exists():
-                    connected_drives.append(path)
-                else:
+                if not circuitpython_only or (path / "boot_out.txt").exists():
                     connected_drives.append(path)
             except PermissionError:
                 if not circuitpython_only:

--- a/bundle_tools/drives.py
+++ b/bundle_tools/drives.py
@@ -46,10 +46,7 @@ def list_connected_drives(circuitpython_only: bool = True, drive_mount_point: Pa
                 connected_drives.append(drive_path.parent)
     elif os_detect.on_mac():
         logger.debug("Platform is Mac OSX!")
-        logger.info("Hey, if this works, please tell me at "
-                    "https://github.com/UnsignedArduino/CircuitPython-Bundle-Manager/issues!")
-        logger.info(f"If it doesn't, still tell me please!")
-        # TODO: Someone test this!
+        drive_mount_point = Path("/Volumes")
         for path in drive_mount_point.glob("*"):
             if circuitpython_only and (path / "boot_out.txt").exists():
                 connected_drives.append(path)

--- a/bundle_tools/modules.py
+++ b/bundle_tools/modules.py
@@ -116,5 +116,5 @@ def uninstall_module(module_path: Path = None) -> None:
     if module_path.is_file():
         module_path.unlink()
     else:
-        rmtree(module_path)
+        rmtree(module_path, ignore_errors=True)
     logger.info(f"Successfully uninstalled {repr(module_path)}!")

--- a/bundle_tools/modules.py
+++ b/bundle_tools/modules.py
@@ -55,6 +55,8 @@ def list_modules(start_path: Path = None) -> list[str]:
         if lib.name[0] != "." # ignore hidden files
     ]
     logger.debug(f"Modules found: {repr(libs)}")
+    # sort the modules here, so we have a stable list
+    libs.sort()
     return libs
 
 

--- a/bundle_tools/modules.py
+++ b/bundle_tools/modules.py
@@ -49,9 +49,11 @@ def list_modules(start_path: Path = None) -> list[str]:
     if not lib_directory.exists():
         logger.error(f"The lib directory '{lib_directory}' does not exist on the CircuitPython device!")
         raise RuntimeError(f"The lib directory '{lib_directory}' does not exist on the CircuitPython device!")
-    libs = list(lib_directory.glob("*"))
-    for index, lib in enumerate(libs):
-        libs[index] = lib.name
+    libs = [
+        lib.name
+        for lib in list(lib_directory.glob("*"))
+        if lib.name[0] != "." # ignore hidden files
+    ]
     logger.debug(f"Modules found: {repr(libs)}")
     return libs
 

--- a/gui.py
+++ b/gui.py
@@ -459,7 +459,6 @@ class GUI(tk.Tk):
             except RuntimeError:
                 logger.exception("Uh oh! Something happened!")
                 installed_modules = []
-            installed_modules.sort()
             logger.debug(f"Installed modules: {repr(installed_modules)}")
             self.installed_modules_listbox_var.set(installed_modules)
         except (AttributeError, RuntimeError):


### PR DESCRIPTION
Hi !
I tested running on mac, so here are a few fixes that came from that.

- On macOS the drives are in `/Volumes`, and since it doesn't make sense to change it on mac, I just hard coded the path and ignored `unix_drive_mount_point`.
- Fixes `circuitpython_only` for mac and linux. Now correctly only lists board drives if the checkbox is not checked.
- Fixed an issue with `shutil.rmtree` choking on extended attributes files on a board, like when a module was installed manually.
- Ignore hidden `.*` files in the device's installed libs (like macOS extended attributes).
- Sort the modules in `modules.list_modules()` so the list is consistent across uses. Avoids deleting the wrong one in `GUI.uninstall_module()` because it was not sorted there but was in the UI. *Is there a way to get the selected module name from the UI ?*
